### PR TITLE
Add basic Python web app in src

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ A minimal repo for experimenting with hook behavior. Use it as a sandbox to veri
 2. Add a hook script under `.git/hooks/` (hooks are local to your clone).
 3. Make a change and run the Git action that should trigger the hook.
 
+## Basic Python Web App
+There is a tiny Python web application under `src/`. Run it with:
+
+```bash
+python src/app.py
+```
+
+Then open `http://127.0.0.1:8000/` in your browser.
+
 ## Example: `pre-commit` Hook
 Create a simple hook that blocks commits containing the word `WIP`:
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,16 @@
+# Basic Python Web App
+
+This folder contains a minimal Python web application using only the standard library.
+
+## Run
+
+```bash
+python src/app.py
+```
+
+Then open `http://127.0.0.1:8000/` in your browser.
+
+## Routes
+
+- `/` : HTML page. Add `?name=Codex` to customize the greeting.
+- `/health` : JSON status response.

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Basic Python web application using the standard library."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from http import HTTPStatus
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+
+
+def _json_response(status: HTTPStatus, payload: dict) -> tuple[str, list[tuple[str, str]], list[bytes]]:
+    body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    headers = [
+        ("Content-Type", "application/json; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+    ]
+    return f"{status.value} {status.phrase}", headers, [body]
+
+
+def _html_response(status: HTTPStatus, html: str) -> tuple[str, list[tuple[str, str]], list[bytes]]:
+    body = html.encode("utf-8")
+    headers = [
+        ("Content-Type", "text/html; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+    ]
+    return f"{status.value} {status.phrase}", headers, [body]
+
+
+def application(environ, start_response):
+    path = environ.get("PATH_INFO", "/")
+    query = parse_qs(environ.get("QUERY_STRING", ""))
+
+    if path == "/":
+        name = query.get("name", ["there"])[0]
+        html = f"""
+        <!doctype html>
+        <html lang=\"en\">
+          <head>
+            <meta charset=\"utf-8\">
+            <title>Hookstest Web App</title>
+          </head>
+          <body>
+            <h1>Hello, {name}!</h1>
+            <p>This is a tiny Python web application running on the standard library.</p>
+            <p>Try <a href=\"/health\">/health</a> or add <code>?name=Codex</code>.</p>
+          </body>
+        </html>
+        """
+        status, headers, body = _html_response(HTTPStatus.OK, html)
+    elif path == "/health":
+        status, headers, body = _json_response(
+            HTTPStatus.OK,
+            {
+                "status": "ok",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    else:
+        status, headers, body = _json_response(
+            HTTPStatus.NOT_FOUND,
+            {"error": "Not Found", "path": path},
+        )
+
+    start_response(status, headers)
+    return body
+
+
+if __name__ == "__main__":
+    host = "127.0.0.1"
+    port = 8000
+    print(f"Serving on http://{host}:{port}")
+    with make_server(host, port, application) as server:
+        server.serve_forever()


### PR DESCRIPTION
Adds a minimal Python web app under src/ using only the standard library, plus run instructions.